### PR TITLE
Add Hugging Face-backed rb:// fsspec filesystem

### DIFF
--- a/emflow/__init__.py
+++ b/emflow/__init__.py
@@ -28,4 +28,11 @@ from .utils.loader import list_problems, load_problem
 from .experiments.experiment import Experiment
 from .experiments.verifier import Verifier
 
-__all__ = ['list_problems', 'load_problem', 'Experiment', 'Verifier']
+# Register the Hugging Face-backed ``rb://`` fsspec filesystem so
+# pandas/polars/duckdb understand it. huggingface_hub is imported lazily on
+# first rb:// use, so this stays cheap and keeps the dep optional at import.
+from .io.rebasefs import RebaseFileSystem, RebaseIncompatibleError, register as _register_rb
+_register_rb()
+
+__all__ = ['list_problems', 'load_problem', 'Experiment', 'Verifier',
+           'RebaseFileSystem', 'RebaseIncompatibleError']

--- a/emflow/io/__init__.py
+++ b/emflow/io/__init__.py
@@ -1,0 +1,5 @@
+"""IO integrations for emflow, including the ``rb://`` fsspec filesystem."""
+
+from .rebasefs import RebaseFileSystem, RebaseIncompatibleError, register
+
+__all__ = ["RebaseFileSystem", "RebaseIncompatibleError", "register"]

--- a/emflow/io/rebasefs.py
+++ b/emflow/io/rebasefs.py
@@ -1,0 +1,189 @@
+"""The ``rb://`` fsspec filesystem for Rebase (rebase.energy).
+
+``rb://`` is a thin, **Hugging Face-backed** scheme: storage lives on the HF Hub
+and the ``rb://`` prefix signals that a given HF dataset/model repo is
+*Rebase-compatible*. Registering it via :mod:`fsspec` is exactly how Hugging
+Face makes ``hf://`` work — once registered, any tool that goes through fsspec
+(pandas, polars, duckdb, pyarrow, ...) understands the scheme.
+
+    >>> import emflow            # registers the ``rb`` protocol on import
+    >>> import pandas as pd
+    >>> df = pd.read_parquet("rb://dataset/acme/wind-farm-a/data.parquet")
+
+URI layout — ``kind`` maps to the HF ``repo_type`` and the rest is the repo id
+plus an in-repo path::
+
+    rb://dataset/<owner>/<repo>/<path>   ->  hf://datasets/<owner>/<repo>/<path>
+    rb://model/<owner>/<repo>/<path>     ->  hf://<owner>/<repo>/<path>
+
+Compatibility: on first access to a repo, the repo is checked for a Rebase
+marker — a ``rebase.yaml``/``rebase.yml``/``rebase.json`` file at the repo root,
+or a ``rebase``/``rebase-compatible`` tag. Repos without a marker raise
+:class:`RebaseIncompatibleError`. Pass ``skip_compat_check=True`` (filesystem
+kwarg) to bypass.
+"""
+
+from __future__ import annotations
+
+from fsspec import AbstractFileSystem, filesystem, register_implementation
+from fsspec.utils import stringify_path
+
+#: rb:// kind -> HF repo_type.
+KIND_TO_REPO_TYPE = {"dataset": "dataset", "model": "model"}
+
+#: Repo-root files that mark a repo as Rebase-compatible.
+MARKER_FILES = ("rebase.yaml", "rebase.yml", "rebase.json")
+
+#: HF tags that mark a repo as Rebase-compatible.
+MARKER_TAGS = ("rebase", "rebase-compatible")
+
+
+class RebaseIncompatibleError(Exception):
+    """Raised when an ``rb://`` repo lacks a Rebase-compatibility marker."""
+
+
+class RebaseFileSystem(AbstractFileSystem):
+    """fsspec filesystem backing the ``rb://`` scheme with Hugging Face storage.
+
+    Read-only. Translates ``rb://<kind>/<owner>/<repo>/<path>`` to the matching
+    ``hf://`` location, verifies Rebase-compatibility once per repo, and
+    delegates byte IO to :class:`huggingface_hub.HfFileSystem`.
+
+    Parameters
+    ----------
+    token:
+        HF token for private repos (falls back to ``HF_TOKEN`` / cached login).
+    endpoint:
+        Custom HF Hub endpoint.
+    skip_compat_check:
+        If True, skip the Rebase-marker verification (treat ``rb://`` as a pure
+        alias for ``hf://``).
+    """
+
+    protocol = "rb"
+    root_marker = ""
+
+    def __init__(self, *args, token=None, endpoint=None,
+                 skip_compat_check=False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._token = token
+        self._skip_compat = skip_compat_check
+        self._compat_cache: dict[tuple[str, str], bool] = {}
+        hf_kwargs = {}
+        if token is not None:
+            hf_kwargs["token"] = token
+        if endpoint is not None:
+            hf_kwargs["endpoint"] = endpoint
+        try:
+            self._hf = filesystem("hf", **hf_kwargs)
+        except ImportError as exc:  # pragma: no cover - depends on env
+            raise ImportError(
+                "rb:// requires huggingface_hub for Hugging Face-backed storage. "
+                "Install it with `pip install huggingface_hub` (or "
+                "`pip install emflow[submissions]`)."
+            ) from exc
+
+    # -- parsing / translation ---------------------------------------------
+
+    @classmethod
+    def _strip_protocol(cls, path) -> str:
+        """Normalise ``rb://dataset/a/b`` (or ``rb:/...`` / ``rb:...``) to ``dataset/a/b``."""
+        path = stringify_path(path)
+        for prefix in ("rb://", "rb:/", "rb:"):
+            if path.startswith(prefix):
+                path = path[len(prefix):]
+                break
+        return path.strip("/")
+
+    def _parse(self, path) -> tuple[str, str, str]:
+        """Return ``(repo_type, repo_id, in_repo_path)`` for an rb path."""
+        rel = self._strip_protocol(path)
+        if not rel:
+            raise FileNotFoundError(
+                "rb:// requires rb://<kind>/<owner>/<repo>[/<path>]"
+            )
+        parts = rel.split("/")
+        kind = parts[0]
+        if kind not in KIND_TO_REPO_TYPE:
+            raise FileNotFoundError(
+                f"rb://{rel}: unknown kind {kind!r} "
+                f"(expected one of {tuple(KIND_TO_REPO_TYPE)})"
+            )
+        if len(parts) < 3:
+            raise FileNotFoundError(
+                f"rb://{rel}: expected rb://{kind}/<owner>/<repo>[/<path>]"
+            )
+        repo_id = f"{parts[1]}/{parts[2]}"
+        in_repo = "/".join(parts[3:])
+        return KIND_TO_REPO_TYPE[kind], repo_id, in_repo
+
+    @staticmethod
+    def _hf_path(repo_type: str, repo_id: str, in_repo: str) -> str:
+        """Build the equivalent ``hf://`` path."""
+        base = repo_id if repo_type == "model" else f"{repo_type}s/{repo_id}"
+        return f"hf://{base}/{in_repo}" if in_repo else f"hf://{base}"
+
+    # -- compatibility marker ----------------------------------------------
+
+    def _is_rebase_compatible(self, repo_type: str, repo_id: str) -> bool:
+        from huggingface_hub import HfApi
+
+        api = HfApi(token=self._token)
+        info = api.repo_info(repo_id=repo_id, repo_type=repo_type,
+                             files_metadata=False)
+        tags = set(getattr(info, "tags", None) or [])
+        if tags.intersection(MARKER_TAGS):
+            return True
+        siblings = getattr(info, "siblings", None) or []
+        names = {s.rfilename for s in siblings}
+        return any(marker in names for marker in MARKER_FILES)
+
+    def _check_compat(self, repo_type: str, repo_id: str) -> None:
+        if self._skip_compat:
+            return
+        key = (repo_type, repo_id)
+        if key not in self._compat_cache:
+            self._compat_cache[key] = self._is_rebase_compatible(*key)
+        if not self._compat_cache[key]:
+            raise RebaseIncompatibleError(
+                f"rb://{repo_type}/{repo_id} is not Rebase-compatible: the repo "
+                f"has none of the marker files {MARKER_FILES} and none of the "
+                f"tags {MARKER_TAGS}. Use hf:// directly, or pass "
+                f"skip_compat_check=True to bypass."
+            )
+
+    def _resolve(self, path) -> str:
+        repo_type, repo_id, in_repo = self._parse(path)
+        self._check_compat(repo_type, repo_id)
+        return self._hf_path(repo_type, repo_id, in_repo)
+
+    # -- fsspec API ---------------------------------------------------------
+
+    def _open(self, path, mode="rb", **kwargs):
+        if any(c in mode for c in "wa+"):
+            raise NotImplementedError("rb:// is read-only")
+        return self._hf.open(self._resolve(path), mode=mode)
+
+    def info(self, path, **kwargs):
+        info = dict(self._hf.info(self._resolve(path)))
+        info["name"] = self._strip_protocol(path)
+        return info
+
+    def ls(self, path, detail=True, **kwargs):
+        return self._hf.ls(self._resolve(path), detail=detail, **kwargs)
+
+    def exists(self, path, **kwargs):
+        try:
+            resolved = self._resolve(path)
+        except (FileNotFoundError, RebaseIncompatibleError, NotImplementedError):
+            return False
+        return self._hf.exists(resolved)
+
+
+def register(clobber: bool = True) -> None:
+    """Register :class:`RebaseFileSystem` under the ``rb`` protocol.
+
+    Called automatically on ``import emflow``. Does not import
+    ``huggingface_hub`` — that happens lazily when ``rb://`` is first used.
+    """
+    register_implementation("rb", RebaseFileSystem, clobber=clobber)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ requires-python = ">=3.12"
 dependencies = [
     "energydatamodel>=0.7.0,<0.8.0",
     "gymnasium>=1.1.1",
+    "fsspec>=2023.1.0",
+    "huggingface_hub>=0.20",  # Hugging Face-backed rb:// filesystem
 ]
 
 [project.urls]
@@ -22,10 +24,18 @@ Homepage = "https://emflow.org"
 Repository = "https://github.com/rebase-energy/emflow"
 Documentation = "https://docs.emflow.org/en/latest"
 
+# Make the ``rb://`` scheme discoverable by fsspec without an explicit
+# ``import emflow`` — same mechanism huggingface_hub uses for ``hf://``.
+[project.entry-points."fsspec.specs"]
+rb = "emflow.io.rebasefs:RebaseFileSystem"
+
 [project.optional-dependencies]
 examples = [
     "matplotlib>=3.8",
     "plotly>=5.0",
+]
+submissions = [
+    "huggingface_hub>=0.20",
 ]
 dev = [
     "build>=1.2.2",

--- a/scripts/verify_submission.py
+++ b/scripts/verify_submission.py
@@ -1,51 +1,118 @@
 """Verify a submitted forecasting model and score it on an emflow problem.
 
 Usage:
-    python scripts/verify_submission.py <path/to/submission.py> \
-        [--problem swedish-temperatures:ar] [--name NAME] \
-        [--leaderboard submissions/leaderboard.csv] [--lookback HOURS]
+    # local file
+    python scripts/verify_submission.py <path/to/submission.py> [...]
+
+    # straight from HuggingFace (intern uploads submission.py to a HF repo)
+    python scripts/verify_submission.py hf://<owner>/<repo>/submission.py \
+        [--revision COMMIT_OR_TAG] [--repo-type model|dataset] [...]
+
+    # ...also: [--problem swedish-temperatures:ar] [--name NAME]
+    #          [--leaderboard submissions/leaderboard.csv] [--lookback HOURS]
 
 The submission file must expose ``get_model() -> emflow.Predictor`` returning a
 *fresh, untrained* predictor. The verifier trains it on the official training split
 and scores it via strict walk-forward (the submitter never sees the test targets), so
 the reported number cannot be inflated by data leakage.
 
-SECURITY: this imports and executes the submission file. Only run code from people
-you trust.
+SECURITY: this imports and executes the submission file (local or downloaded). Only
+run code from people you trust, and prefer pinning ``--revision`` to a commit SHA.
 """
 
 import argparse
 import importlib.util
+import os
 from pathlib import Path
 
+import emflow as ef
 from emflow.experiments.verifier import Verifier, DEFAULT_LEADERBOARD
 
 
+def resolve_to_local(ref: str, revision=None, repo_type="model") -> Path:
+    """Resolve a submission reference to a local file path.
+
+    Accepts a plain local path, or a ``hf://<owner>/<repo>/<path-in-repo>`` URI which is
+    downloaded from the HuggingFace Hub (uses HF_TOKEN/HUGGINGFACE_TOKEN if set, for
+    private repos).
+    """
+    if not ref.startswith("hf://"):
+        return Path(ref)
+
+    try:
+        from huggingface_hub import hf_hub_download
+    except ModuleNotFoundError as e:
+        raise SystemExit(
+            "huggingface_hub is required for hf:// submissions — "
+            "install it with:  uv sync --extra submissions"
+        ) from e
+
+    parts = ref[len("hf://"):].split("/")
+    if len(parts) < 2:
+        raise SystemExit("hf:// reference must be hf://<owner>/<repo>[/<file>]")
+    repo_id = "/".join(parts[:2])
+    filename = "/".join(parts[2:]) or "submission.py"
+    token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGINGFACE_TOKEN")
+    print(f"Downloading {filename} from HF {repo_type} repo {repo_id}"
+          f"{' @ ' + revision if revision else ''} ...")
+    return Path(hf_hub_download(repo_id=repo_id, filename=filename,
+                                repo_type=repo_type, revision=revision, token=token))
+
+
 def load_submission(path: Path):
-    """Import a submission module from a file path and return its get_model()."""
+    """Import a submission module and return the submitted Predictor.
+
+    Accepts either form — whichever the submitter prefers:
+      * a module-level ``emflow.Predictor`` instance (e.g. ``model = MyModel()``), or
+      * a ``get_model() -> emflow.Predictor`` factory that returns a fresh model.
+
+    Either way the verifier trains the model itself on the official split, so the
+    leakage guarantees are identical.
+    """
     spec = importlib.util.spec_from_file_location(path.stem, path)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
-    if not hasattr(module, "get_model"):
+
+    # Factory form (back-compatible with the original template).
+    if hasattr(module, "get_model"):
+        return module.get_model()
+
+    # Bare-object form: a module-level Predictor instance. Prefer one named
+    # `model`, else fall back to the sole Predictor instance in the module.
+    candidate = getattr(module, "model", None)
+    if isinstance(candidate, ef.Predictor):
+        return candidate
+    instances = [v for v in vars(module).values() if isinstance(v, ef.Predictor)]
+    if len(instances) == 1:
+        return instances[0]
+    if len(instances) > 1:
         raise AttributeError(
-            f"{path} must define get_model() -> emflow.Predictor (returning a fresh model)"
+            f"{path} defines several emflow.Predictor instances — name the one to "
+            f"submit as `model = ...`, or expose get_model()."
         )
-    return module.get_model()
+    raise AttributeError(
+        f"{path} must define `model = <emflow.Predictor>` or "
+        f"get_model() -> emflow.Predictor"
+    )
 
 
 def main():
     ap = argparse.ArgumentParser(description="Verify a submitted Predictor model.")
-    ap.add_argument("submission", type=Path, help="path to the submission .py file")
+    ap.add_argument("submission", help="local path OR hf://<owner>/<repo>/submission.py")
     ap.add_argument("--problem", default="swedish-temperatures:ar")
     ap.add_argument("--name", default=None, help="submission name for the scorecard/leaderboard")
     ap.add_argument("--leaderboard", default=str(DEFAULT_LEADERBOARD))
     ap.add_argument("--lookback", type=int, default=None,
                     help="trailing hours of history per step (default: full history)")
+    ap.add_argument("--revision", default=None, help="HF commit SHA / tag / branch to pin")
+    ap.add_argument("--repo-type", default="model", choices=["model", "dataset"],
+                    help="HF repo type for hf:// references (default: model)")
     args = ap.parse_args()
 
-    print(f"⚠  Importing and running {args.submission} — only do this for trusted code.")
-    model = load_submission(args.submission)
-    name = args.name or args.submission.stem
+    path = resolve_to_local(args.submission, revision=args.revision, repo_type=args.repo_type)
+    print(f"⚠  Importing and running {path} — only do this for trusted code.")
+    model = load_submission(path)
+    name = args.name or path.stem
 
     verifier = Verifier(problem=args.problem, leaderboard_path=args.leaderboard)
     verifier.verify(model, name=name, lookback=args.lookback)

--- a/submissions/README.md
+++ b/submissions/README.md
@@ -35,7 +35,34 @@ Subclass `emflow.Predictor` (see `template_submission.py`):
    This prints a scorecard (your MAE/RMSE vs persistence and seasonal-naive baselines,
    `PASS` if you beat persistence) and appends a row to `submissions/leaderboard.csv`.
 
-3. Send your `submission.py`. We run the same command to produce the official score.
+3. Submit your model — either send the `submission.py` file directly, or upload it to a
+   HuggingFace repo (see below).
+
+## Submit via HuggingFace
+
+The intern uploads `submission.py` to a HuggingFace repo and shares the repo id:
+
+```python
+from huggingface_hub import HfApi
+api = HfApi()                                  # set HF_TOKEN for a private repo
+api.create_repo("your-username/emflow-submission", repo_type="model", exist_ok=True)
+api.upload_file(path_or_fileobj="submission.py", path_in_repo="submission.py",
+                repo_id="your-username/emflow-submission", repo_type="model")
+```
+
+The evaluator then verifies it straight from the Hub (needs the `submissions` extra:
+`uv sync --extra submissions`):
+
+```bash
+python scripts/verify_submission.py hf://your-username/emflow-submission/submission.py \
+    --revision <commit-sha>          # pin a commit for reproducibility (recommended)
+# add --repo-type dataset if it was uploaded to a dataset repo
+```
+
+For a private repo, set `HF_TOKEN` (or `HUGGINGFACE_TOKEN`) in the environment before
+running. The downloaded file is then trained + scored by the same strict walk-forward
+verifier, so the leakage guarantees are identical to the local path.
 
 > **Note (for whoever runs the verifier):** `verify_submission.py` imports and executes
-> the submission file. Only run code from people you trust.
+> the submission file — local *or downloaded from HuggingFace*. Only run code from people
+> you trust, and prefer pinning `--revision` to a commit SHA.

--- a/submissions/example_submission.py
+++ b/submissions/example_submission.py
@@ -1,0 +1,133 @@
+"""Example submission — a reference for how a model submission should look.
+
+This is a *complete, self-contained* example for the ``swedish-temperatures:ar``
+problem. Copy it, rename ``ExamplePredictor`` to your own model, and replace the
+``train`` / ``predict`` bodies. The only thing the verifier needs is a module-level
+``emflow.Predictor`` instance:
+
+    model = ExamplePredictor()      # a FRESH, UNTRAINED model
+
+The verifier (``scripts/verify_submission.py``) will:
+  1. pick up your ``model`` (untrained),
+  2. train it on the official pre-2026 split via ``model.train(train_df)``,
+  3. score it with **strict walk-forward** on the held-out 2026 hours.
+
+(If you prefer, you can instead expose a ``get_model() -> emflow.Predictor``
+factory — the verifier accepts either form.)
+
+You never see the test targets and you cannot train on them, so the score is
+trustworthy. Self-check before submitting::
+
+    python scripts/verify_submission.py submissions/example_submission.py
+
+----------------------------------------------------------------------------
+The model
+----------------------------------------------------------------------------
+A least-squares autoregression on the most recent hours:
+
+    y_t = c + sum_i w_i * y_{t-lag_i}        (lags = 1, 2, 3 hours)
+
+Fit per column with ``numpy.linalg.lstsq`` — no scikit-learn / statsmodels
+needed. Short lags are deliberately strong for *1-step-ahead* hourly
+temperature, and this comfortably beats the persistence and seasonal-naive
+baselines.
+
+Want to do better? This is where the intern earns their keep — e.g. add the
+daily/weekly lags (24, 168), a per-hour-of-day or per-month offset, exogenous
+NWP features, or swap the OLS for a gradient-boosted / neural model. Keep the
+same ``train`` / ``predict`` contract and the verifier scores it the same way.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+import emflow as ef
+
+
+class ExamplePredictor(ef.Predictor):
+    """OLS autoregression on recent lags, fit independently per column.
+
+    Parameters
+    ----------
+    lags : iterable of int
+        Lag orders (hours) used as regressors. Default: 1, 2, 3.
+    name : str
+        Submission name shown on the scorecard / leaderboard.
+    """
+
+    def __init__(self, lags=(1, 2, 3), name="example-ar"):
+        # IMPORTANT: set self.name so the scorecard / leaderboard can label you.
+        self.name = name
+        self.lags = sorted(lags)
+        self.max_lag = max(self.lags)
+        # column -> (intercept: float, weights: ndarray) or None if unfit
+        self.coefs: dict = {}
+
+    # -- feature construction -------------------------------------------------
+    def _design_matrix(self, series: pd.Series) -> np.ndarray:
+        """Build an (n_obs, n_lags) matrix of lagged values.
+
+        Row ``t`` holds the values at ``t-lag`` for each lag — i.e. only the
+        past, never the value at ``t`` itself. That is what keeps the model
+        honest under walk-forward evaluation.
+        """
+        return np.column_stack([series.shift(lag).to_numpy() for lag in self.lags])
+
+    # -- training -------------------------------------------------------------
+    def train(self, train_df):
+        """Fit one AR model per column via least squares on complete rows only.
+
+        Rows with any NaN in the target or its required lags are dropped before
+        fitting. A column with too little data is left unfit (predicts NaN).
+        """
+        if isinstance(train_df, pd.Series):
+            train_df = train_df.to_frame()
+
+        self.coefs = {}
+        for col in train_df.columns:
+            series = train_df[col]
+            X = self._design_matrix(series)
+            y = series.to_numpy()
+            mask = np.isfinite(y) & np.isfinite(X).all(axis=1)
+            if mask.sum() <= len(self.lags) + 1:  # need more rows than params
+                self.coefs[col] = None
+                continue
+            X_fit = np.column_stack([np.ones(mask.sum()), X[mask]])
+            beta, *_ = np.linalg.lstsq(X_fit, y[mask], rcond=None)
+            self.coefs[col] = (float(beta[0]), beta[1:])
+        return self
+
+    # -- prediction -----------------------------------------------------------
+    def predict(self, input):
+        """1-step-ahead forecast for every timestamp in ``input``.
+
+        Returns a DataFrame sharing ``input``'s index/columns. The verifier reads
+        the value at the LAST timestamp of ``input`` (whose actual is hidden as
+        NaN) as your forecast for that hour. Rows whose lags are missing — or
+        unfit columns — stay NaN.
+        """
+        if isinstance(input, pd.Series):
+            input = input.to_frame()
+
+        preds = {}
+        for col in input.columns:
+            series = input[col]
+            coef = self.coefs.get(col)
+            if coef is None:
+                preds[col] = np.full(len(series), np.nan)
+                continue
+            intercept, weights = coef
+            X = self._design_matrix(series)
+            out = np.full(len(series), np.nan)
+            finite = np.isfinite(X).all(axis=1)  # only score rows with all lags present
+            with np.errstate(divide="ignore", over="ignore", invalid="ignore"):
+                out[finite] = intercept + X[finite] @ weights
+            preds[col] = out
+
+        return pd.DataFrame(preds, index=input.index, columns=input.columns)
+
+
+# The submission: a FRESH, UNTRAINED predictor for the verifier to train + score.
+model = ExamplePredictor()

--- a/submissions/leaderboard.csv
+++ b/submissions/leaderboard.csv
@@ -1,0 +1,2 @@
+submitted_at,submission,problem,mode,metric_name,mae,rmse,n_points,persistence_mae,beats_persistence
+2026-06-02T15:37:44,example-submission,swedish-temperatures:ar,strict walk-forward (leakage impossible by construction),MeanAbsoluteError,0.2879,0.3994,1423,0.3125,True

--- a/uv.lock
+++ b/uv.lock
@@ -20,6 +20,28 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
 name = "appnope"
 version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -174,6 +196,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cd/e5/131d2fb1b0dddafc37be4f3a2fa79aa4c037368be9423061dccadfd90091/charset_normalizer-3.4.1-cp313-cp313-win32.whl", hash = "sha256:eb8178fe3dba6450a3e024e95ac49ed3400e506fd4e9e5c32d30adda88cbd407", size = 95391, upload-time = "2024-12-24T18:11:24.139Z" },
     { url = "https://files.pythonhosted.org/packages/27/f2/4f9a69cc7712b9b5ad8fdb87039fd89abba997ad5cbe690d1835d40405b0/charset_normalizer-3.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:b1ac5992a838106edb89654e0aebfc24f5848ae2547d22c2c3f66454daa11971", size = 102702, upload-time = "2024-12-24T18:11:26.535Z" },
     { url = "https://files.pythonhosted.org/packages/0e/f6/65ecc6878a89bb1c23a086ea335ad4bf21a588990c3f535a227b9eea9108/charset_normalizer-3.4.1-py3-none-any.whl", hash = "sha256:d98b1668f06378c6dbefec3b92299716b931cd4e6061f3c875a71ced1780ab85", size = 49767, upload-time = "2024-12-24T18:12:32.852Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
 ]
 
 [[package]]
@@ -361,7 +395,9 @@ version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "energydatamodel" },
+    { name = "fsspec" },
     { name = "gymnasium" },
+    { name = "huggingface-hub" },
 ]
 
 [package.optional-dependencies]
@@ -381,12 +417,18 @@ examples = [
     { name = "matplotlib" },
     { name = "plotly" },
 ]
+submissions = [
+    { name = "huggingface-hub" },
+]
 
 [package.metadata]
 requires-dist = [
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.2.2" },
     { name = "energydatamodel", specifier = ">=0.7.0,<0.8.0" },
+    { name = "fsspec", specifier = ">=2023.1.0" },
     { name = "gymnasium", specifier = ">=1.1.1" },
+    { name = "huggingface-hub", specifier = ">=0.20" },
+    { name = "huggingface-hub", marker = "extra == 'submissions'", specifier = ">=0.20" },
     { name = "ipykernel", marker = "extra == 'dev'", specifier = ">=6.29.5" },
     { name = "ipywidgets", marker = "extra == 'dev'", specifier = ">=8.1.5" },
     { name = "matplotlib", marker = "extra == 'examples'", specifier = ">=3.8" },
@@ -399,7 +441,7 @@ requires-dist = [
     { name = "sphinx-rtd-theme", marker = "extra == 'dev'", specifier = ">=3.0.2" },
     { name = "twine", marker = "extra == 'dev'", specifier = ">=6.1.0" },
 ]
-provides-extras = ["examples", "dev"]
+provides-extras = ["examples", "submissions", "dev"]
 
 [[package]]
 name = "energydatamodel"
@@ -447,6 +489,15 @@ wheels = [
 ]
 
 [[package]]
+name = "filelock"
+version = "3.29.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
+]
+
+[[package]]
 name = "fonttools"
 version = "4.63.0"
 source = { registry = "https://pypi.org/simple" }
@@ -488,6 +539,15 @@ wheels = [
 ]
 
 [[package]]
+name = "fsspec"
+version = "2026.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/8d/1c51c094345df128ca4a990d633fe1a0ff28726c9e6b3c41ba65087bba1d/fsspec-2026.4.0.tar.gz", hash = "sha256:301d8ac70ae90ef3ad05dcf94d6c3754a097f9b5fe4667d2787aa359ec7df7e4", size = 312760, upload-time = "2026-04-29T20:42:38.635Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl", hash = "sha256:11ef7bb35dab8a394fde6e608221d5cf3e8499401c249bebaeaad760a1a8dec2", size = 203402, upload-time = "2026-04-29T20:42:36.842Z" },
+]
+
+[[package]]
 name = "geopandas"
 version = "1.1.3"
 source = { registry = "https://pypi.org/simple" }
@@ -519,6 +579,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/69/70cd29e9fc4953d013b15981ee71d4c9ef4d8b2183e6ef2fe89756746dce/gymnasium-1.1.1.tar.gz", hash = "sha256:8bd9ea9bdef32c950a444ff36afc785e1d81051ec32d30435058953c20d2456d", size = 829326, upload-time = "2025-03-06T16:30:36.428Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/68/2bdc7b46b5f543dd865575f9d19716866bdb76e50dd33b71ed1a3dd8bb42/gymnasium-1.1.1-py3-none-any.whl", hash = "sha256:9c167ec0a2b388666e37f63b2849cd2552f7f5b71938574c637bb36487eb928a", size = 965410, upload-time = "2025-03-06T16:30:34.443Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
 ]
 
 [[package]]
@@ -563,6 +632,87 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/41/8c/bbe98f813722b4873818a8db3e15aa3e625b59278566905ac439725e8070/h5py-3.16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:346df559a0f7dcb31cf8e44805319e2ab24b8957c45e7708ce503b2ec79ba725", size = 5300253, upload-time = "2026-03-06T13:49:02.033Z" },
     { url = "https://files.pythonhosted.org/packages/32/9e/87e6705b4d6890e7cecdf876e2a7d3e40654a2ae37482d79a6f1b87f7b92/h5py-3.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:4c6ab014ab704b4feaa719ae783b86522ed0bf1f82184704ed3c9e4e3228796e", size = 3381671, upload-time = "2026-03-06T13:49:04.351Z" },
     { url = "https://files.pythonhosted.org/packages/96/91/9fad90cfc5f9b2489c7c26ad897157bce82f0e9534a986a221b99760b23b/h5py-3.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:faca8fb4e4319c09d83337adc80b2ca7d5c5a343c2d6f1b6388f32cfecca13c1", size = 2740706, upload-time = "2026-03-06T13:49:06.347Z" },
+]
+
+[[package]]
+name = "hf-xet"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/d8/5c06fc76461418326a7decf8367480c35be11a41fd938633929c60a9ec6b/hf_xet-1.5.0.tar.gz", hash = "sha256:e0fb0a34d9f406eed88233e829a67ec016bec5af19e480eac65a233ea289a948", size = 837196, upload-time = "2026-05-06T06:18:15.583Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/9b/6912c99070915a4f28119e3c5b52a9abd1eec0ad5cb293b8c967a0c6f5a2/hf_xet-1.5.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:7d70fe2ce97b9db73b9c9b9c81fe3693640aec83416a966c446afea54acfae3c", size = 4023383, upload-time = "2026-05-06T06:17:53.947Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/6d/9563cfde59b5d8128a9c7ec972a087f4c782e4f7bac5a85234edfd5d5e49/hf_xet-1.5.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:73a0dae8c71de3b0633a45c73f4a4a5ed09e94b43441d82981a781d4f12baa42", size = 3792751, upload-time = "2026-05-06T06:17:51.791Z" },
+    { url = "https://files.pythonhosted.org/packages/07/a5/ed5a0cf35b49a0571af5a8f53416dad1877a718c021c9937c3a53cb45781/hf_xet-1.5.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a60290ec57e9b71767fba7c3645ddafdd0759974b540441510c629c6db6db24a", size = 4456058, upload-time = "2026-05-06T06:17:40.735Z" },
+    { url = "https://files.pythonhosted.org/packages/60/fb/3ae8bf2a7a37a4197d0195d7247fd25b3952e15cb8a599e285dfaa6f52b3/hf_xet-1.5.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:e5de0f6deada0dada870bb376a11bcd1f08abf3a968a6d118f33e72d1b1eb480", size = 4250783, upload-time = "2026-05-06T06:17:38.412Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/9b/8bae40d4d91525085137196e84eb0ed49cf65b5e96e5c3ecdadd8bd0fac2/hf_xet-1.5.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c799d49f1a5544a0ef7591c0ee75e0d6b93d6f56dc7a4979f59f7518d2872216", size = 4445594, upload-time = "2026-05-06T06:18:04.219Z" },
+    { url = "https://files.pythonhosted.org/packages/13/59/c74efbbd4e8728172b2cc72a2bc014d2947a4b7bdced932fbd3f5da1a4e5/hf_xet-1.5.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2baea1b0b989e5c152fe81425f7745ddc8901280ba3d97c98d8cdece7b706c60", size = 4663995, upload-time = "2026-05-06T06:18:06.1Z" },
+    { url = "https://files.pythonhosted.org/packages/73/32/8e1e0410af64cda9b139d1dcebdc993a8ff9c8c7c0e2696ae356d75ccc0d/hf_xet-1.5.0-cp313-cp313t-win_amd64.whl", hash = "sha256:526345b3ed45f374f6317349df489167606736c876241ba984105afe7fd4839d", size = 3966608, upload-time = "2026-05-06T06:18:19.74Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/34/a8febc8f4edbea8b3e21b02ebc8b628679b84ba7e45cde624a7736b51500/hf_xet-1.5.0-cp313-cp313t-win_arm64.whl", hash = "sha256:786d28e2eb8315d5035544b9d137b4a842d600c434bb91bf7d0d953cce906ad4", size = 3796946, upload-time = "2026-05-06T06:18:17.568Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/20/8fc8996afe5815fa1a6be8e9e5c02f24500f409d599e905800d498a4e14d/hf_xet-1.5.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:872d5601e6deea30d15865ede55d29eac6daf5a534ab417b99b6ef6b076dd96c", size = 4023495, upload-time = "2026-05-06T06:18:01.94Z" },
+    { url = "https://files.pythonhosted.org/packages/32/6a/93d84463c00cecb561a7508aa6303e35ee2894294eac14245526924415fe/hf_xet-1.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9929561f5abf4581c8ea79587881dfef6b8abb2a0d8a51915936fc2a614f4e73", size = 3792731, upload-time = "2026-05-06T06:18:00.021Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/5a/8ec8e0c863b382d00b3c2e2af6ded6b06371be617144a625903a6d562f4b/hf_xet-1.5.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f7b7bbae318e583a86fb21e5a4a175d6721d628a2874f4bd022d0e660c32a682", size = 4456738, upload-time = "2026-05-06T06:17:49.574Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/ca/f7effa1a67717da2bcc6b6c28f71c6ca648c77acaec4e2c32f40cbe16d85/hf_xet-1.5.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:cf7b2dc6f31a4ea754bb50f74cde482dcf5d366d184076d8530b9872787f3761", size = 4251622, upload-time = "2026-05-06T06:17:47.096Z" },
+    { url = "https://files.pythonhosted.org/packages/65/f2/19247dba3e231cf77dec59ddfb878f00057635ff773d099c9b59d37812c3/hf_xet-1.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8dbcbab554c9ef158ef2c991545c3e970ddd8cc7acdcd0a78c5a41095dab4ded", size = 4445667, upload-time = "2026-05-06T06:18:11.983Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/64/6f116801a3bcfb6f59f5c251f48cadc47ea54026441c4a385079286a94fa/hf_xet-1.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5906bf7718d3636dc13402914736abe723492cb730f744834f5f5b67d3a12702", size = 4664619, upload-time = "2026-05-06T06:18:13.771Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e8/069542d37946ed08669b127e1496fa99e78196d71de8d41eda5e9f1b7a58/hf_xet-1.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:5f3dc2248fc01cc0a00cd392ab497f1ca373fcbc7e3f2da1f452480b384e839e", size = 3966802, upload-time = "2026-05-06T06:18:28.162Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/91/fc6fdec27b14d04e88c386ac0a0129732b53fa23f7c4a78f4b83a039c567/hf_xet-1.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:b285cea1b5bab46b758772716ba8d6854a1a0310fed1c249d678a8b38601e5a0", size = 3797168, upload-time = "2026-05-06T06:18:26.287Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/fb/69ff198a82cae7eb1a69fb84d93b3a3e4816564d76817fe541ddc96874eb/hf_xet-1.5.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:dad0dc84e941b8ba3c860659fe1fdc35c049d47cce293f003287757e971a8f56", size = 4030814, upload-time = "2026-05-06T06:17:57.933Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ff/edcc2b40162bef3ff78e14ab637e5f3b89243d6aee72f5949d3bb6a5af83/hf_xet-1.5.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:fd6e5a9b0fdac4ed03ed45ef79254a655b1aaab514a02202617fbf643f5fdf7a", size = 3798444, upload-time = "2026-05-06T06:17:55.79Z" },
+    { url = "https://files.pythonhosted.org/packages/49/4d/103f76b04310e5e57656696cc184690d20c466af0bca3ca88f8c8ea5d4f3/hf_xet-1.5.0-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3531b1823a0e6d77d80f9ed15ca0e00f0d115094f8ac033d5cae88f4564cc949", size = 4465986, upload-time = "2026-05-06T06:17:44.886Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/a2/546f47f464737b3edbab6f8ddb57f2599b93d2cbb66f06abb475ccb48651/hf_xet-1.5.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9a0ee58cd18d5ea799f7ed11290bbccbe56bdd8b1d97ca74b9cc49a3945d7a3b", size = 4259865, upload-time = "2026-05-06T06:17:42.639Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7f/1be593c1f28613be2e196473481cd81bfc5910795e30a34e8f744f6cac4f/hf_xet-1.5.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e60df5a42e9bed8628b6416af2cba4cba57ae9f02de226a06b020d98e1aab18", size = 4459835, upload-time = "2026-05-06T06:18:08.026Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b2/703569fc881f3284487e68cda7b42179978480da3c438042a6bbbb4a671c/hf_xet-1.5.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4b35549ce62601b84da4ff9b24d970032ace3d4430f52d91bcbb26c901d6c690", size = 4672414, upload-time = "2026-05-06T06:18:09.864Z" },
+    { url = "https://files.pythonhosted.org/packages/af/37/1b6def445c567286b50aa3b33828158e135b1be44938dde59f11382a500c/hf_xet-1.5.0-cp37-abi3-win_amd64.whl", hash = "sha256:2806c7c17b4d23f8d88f7c4814f838c3b6150773fe339c20af23e1cfaf2797e4", size = 3977238, upload-time = "2026-05-06T06:18:23.621Z" },
+    { url = "https://files.pythonhosted.org/packages/62/94/3b66b148778ee100dcfd69c2ca22b57b41b44d3063ceec934f209e9184ce/hf_xet-1.5.0-cp37-abi3-win_arm64.whl", hash = "sha256:b6c9df403040248c76d808d3e047d64db2d923bae593eb244c41e425cf6cd7be", size = 3806916, upload-time = "2026-05-06T06:18:21.7Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/65/9826515abb600b5722bcf53f8b4a2fb58340b1f8bfcaee19f83561c13a44/huggingface_hub-1.17.0.tar.gz", hash = "sha256:fad842b6763ef70ebc3919665b1b9273645203185400a7d6c5eddc2323cc3435", size = 797082, upload-time = "2026-05-28T15:12:13.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/28/d7cef5e477b855c25d415b8f57e5bc7347c7a90cad3acf1725d0c92ca294/huggingface_hub-1.17.0-py3-none-any.whl", hash = "sha256:3b8156d23118e87f6a587648bfbc04f04a12a757ccb4ed298b35c4ae638bf24c", size = 671546, upload-time = "2026-05-28T15:12:11.441Z" },
 ]
 
 [[package]]
@@ -2102,6 +2252,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2304,6 +2463,18 @@ wheels = [
 ]
 
 [[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
 name = "traitlets"
 version = "5.14.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2330,6 +2501,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c8/a2/6df94fc5c8e2170d21d7134a565c3a8fb84f9797c1dd65a5976aaf714418/twine-6.1.0.tar.gz", hash = "sha256:be324f6272eff91d07ee93f251edf232fc647935dd585ac003539b42404a8dbd", size = 168404, upload-time = "2025-01-21T18:45:26.758Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7c/b6/74e927715a285743351233f33ea3c684528a0d374d2e43ff9ce9585b73fe/twine-6.1.0-py3-none-any.whl", hash = "sha256:a47f973caf122930bf0fbbf17f80b83bc1602c9ce393c7845f289a3001dc5384", size = 40791, upload-time = "2025-01-21T18:45:24.584Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276, upload-time = "2026-04-30T19:32:16.964Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/f9/2b3ff4e56e5fa7debfaf9eb135d0da96f3e9a1d5b27222223c7296336e5f/typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89", size = 58409, upload-time = "2026-04-30T19:32:18.271Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds an `rb://` fsspec filesystem backed by Hugging Face storage, where the `rb://` prefix signals that an HF dataset/model repo is **Rebase-compatible**. Registered the same way huggingface_hub registers `hf://`, so any fsspec-aware tool (pandas, polars, duckdb, pyarrow) understands it.

```python
import pandas as pd
df = pd.read_parquet("rb://dataset/acme/wind-farm-a/data.parquet")
```

URI layout (`kind` → HF `repo_type`):

```
rb://dataset/<owner>/<repo>/<path>  ->  hf://datasets/<owner>/<repo>/<path>
rb://model/<owner>/<repo>/<path>    ->  hf://<owner>/<repo>/<path>
```

## Behavior

- **Compatibility marker**: on first access, the repo is checked for a `rebase.yaml`/`.yml`/`.json` file at root or a `rebase`/`rebase-compatible` tag. Missing → `RebaseIncompatibleError`. `skip_compat_check=True` bypasses. Result cached per repo (one metadata lookup).
- **Lazy deps**: `huggingface_hub` is imported only on first `rb://` use, so `import emflow` stays cheap.
- **Global discovery**: a `[fsspec.specs]` entry point makes `rb://` resolvable in any environment that has emflow installed — no explicit `import emflow` needed (parity with `hf://`).
- Read-only for now.

## Verified

- Path translation (dataset + model, with/without in-repo path); malformed URIs rejected with clear messages.
- Compat gate: pass → open, fail → `RebaseIncompatibleError`, cached.
- `import emflow` does **not** import `huggingface_hub`.
- Entry-point discovery works in a fresh process with no `import emflow`.
- **Live**: listed + `read_parquet` of 1,319 rows from `openai/gsm8k` over `rb://`; default compat gate correctly rejected that repo (no marker).

## Note

This branch also carries pre-existing work-in-progress (submission verifier example/template + leaderboard) in a separate commit, included per "push everything".

🤖 Generated with [Claude Code](https://claude.com/claude-code)